### PR TITLE
Support event-driven streaming async

### DIFF
--- a/R/multi.R
+++ b/R/multi.R
@@ -199,6 +199,5 @@ print.curl_multi <- function(x, ...){
 multi_fdset <- function(pool = NULL){
   if(is.null(pool))
     pool <- multi_default()
-  stopifnot(inherits(pool, c("curl_multi", "curl")))
   .Call(R_multi_fdset, pool)
 }

--- a/R/multi.R
+++ b/R/multi.R
@@ -199,5 +199,7 @@ print.curl_multi <- function(x, ...){
 multi_fdset <- function(pool = NULL){
   if(is.null(pool))
     pool <- multi_default()
+  # below duplicates checks made by C code, but may need to be reinstated if that ever changes
+  # stopifnot(inherits(pool, c("curl_multi", "curl")))
   .Call(R_multi_fdset, pool)
 }

--- a/R/multi.R
+++ b/R/multi.R
@@ -199,6 +199,6 @@ print.curl_multi <- function(x, ...){
 multi_fdset <- function(pool = NULL){
   if(is.null(pool))
     pool <- multi_default()
-  stopifnot(inherits(pool, "curl_multi"))
+  stopifnot(inherits(pool, c("curl_multi", "curl")))
   .Call(R_multi_fdset, pool)
 }

--- a/src/curl.c
+++ b/src/curl.c
@@ -290,9 +290,8 @@ SEXP R_curl_connection(SEXP url, SEXP ptr, SEXP partial) {
   /* protect the handle */
   (req->ref->refCount)++;
 
-  SEXP xptr;
-  PROTECT(xptr = R_MakeExternalPtr(req->manager, R_NilValue, R_NilValue));
-  SETCDR(Rf_getAttrib(rc, Rf_install("conn_id")), xptr); // SET EXTPTR_PROT
+  SEXP xptr = PROTECT(R_MakeExternalPtr(req->manager, R_NilValue, R_NilValue));
+  R_SetExternalPtrProtected(Rf_getAttrib(rc, Rf_install("conn_id")), xptr);
 
   UNPROTECT(2);
   return rc;

--- a/src/curl.c
+++ b/src/curl.c
@@ -291,10 +291,9 @@ SEXP R_curl_connection(SEXP url, SEXP ptr, SEXP partial) {
   (req->ref->refCount)++;
 
   /* store an accessible reference to the CURLM */
-  SEXP xptr = PROTECT(R_MakeExternalPtr(req->manager, R_NilValue, R_NilValue));
   /* con->ex_ptr is where the 'conn_id' attribute is also stored */
-  R_SetExternalPtrProtected((SEXP) con->ex_ptr, xptr);
+  R_SetExternalPtrAddr((SEXP) con->ex_ptr, req->manager);
 
-  UNPROTECT(2);
+  UNPROTECT(1);
   return rc;
 }

--- a/src/curl.c
+++ b/src/curl.c
@@ -115,19 +115,16 @@ static void fetchdata(request *req) {
 static size_t rcurl_read(void *target, size_t sz, size_t ni, Rconnection con) {
   request *req = (request*) con->private;
   size_t req_size = sz * ni;
-
-  if (!con->blocking || req->partial) {
-    // If the connection is non-blocking (or using curl_fetch_stream()), always
-    // fetch data first (as likely to be called when file descriptor has been
-    // indicated ready for reading). Then just return what's available without
-    // waiting.
-    fetchdata(req);
-    size_t total_size = pop(target, req_size, req);
+  size_t total_size = pop(target, req_size, req);
+  if (total_size > 0 && (!con->blocking || req->partial)) {
+    // If we can return data without waiting, and the connection is
+    // non-blocking (or using curl_fetch_stream()), do so.
+    // This ensures that bytes we already received get flushed
+    // to the target buffer before a connection error.
     con->incomplete = req->has_more || req->size;
     return total_size;
   }
 
-  size_t total_size = pop(target, req_size, req);
   while((req_size > total_size) && req->has_more) {
     int numfds;
     if(con->blocking)
@@ -135,6 +132,9 @@ static size_t rcurl_read(void *target, size_t sz, size_t ni, Rconnection con) {
     fetchdata(req);
     total_size += pop((char*)target + total_size, (req_size-total_size), req);
 
+    //return less than requested data for non-blocking connections, or curl_fetch_stream()
+    if(!con->blocking || req->partial)
+      break;
   }
   con->incomplete = req->has_more || req->size;
   return total_size;

--- a/src/curl.c
+++ b/src/curl.c
@@ -292,7 +292,8 @@ SEXP R_curl_connection(SEXP url, SEXP ptr, SEXP partial) {
 
   /* store an accessible reference to the CURLM */
   SEXP xptr = PROTECT(R_MakeExternalPtr(req->manager, R_NilValue, R_NilValue));
-  R_SetExternalPtrProtected(Rf_getAttrib(rc, Rf_install("conn_id")), xptr);
+  /* con->ex_ptr is where the 'conn_id' attribute is also stored */
+  R_SetExternalPtrProtected((SEXP) con->ex_ptr, xptr);
 
   UNPROTECT(2);
   return rc;

--- a/src/curl.c
+++ b/src/curl.c
@@ -290,6 +290,7 @@ SEXP R_curl_connection(SEXP url, SEXP ptr, SEXP partial) {
   /* protect the handle */
   (req->ref->refCount)++;
 
+  /* store an accessible reference to the CURLM */
   SEXP xptr = PROTECT(R_MakeExternalPtr(req->manager, R_NilValue, R_NilValue));
   R_SetExternalPtrProtected(Rf_getAttrib(rc, Rf_install("conn_id")), xptr);
 

--- a/src/multi.c
+++ b/src/multi.c
@@ -19,7 +19,9 @@ multiref *get_multiref(SEXP ptr){
 CURLM *get_curlm(SEXP ptr){
   CURLM *multi;
   if(Rf_inherits(ptr, "curl")){
-    ptr = R_ExternalPtrProtected(Rf_getAttrib(ptr, Rf_install("conn_id")));
+    ptr = Rf_getAttrib(ptr, Rf_install("conn_id"));
+    if (TYPEOF(ptr) != EXTPTRSXP)
+      Rf_error("pool ptr is not a curl connection");
     multi = (CURLM*) R_ExternalPtrAddr(ptr);
     if(!multi)
       Rf_error("CURLM pointer is dead");

--- a/src/multi.c
+++ b/src/multi.c
@@ -1,27 +1,6 @@
 #include "curl-common.h"
 #include <time.h>
 
-/* the RConnection API is experimental and subject to change */
-#include <R_ext/Connections.h>
-#if ! defined(R_CONNECTIONS_VERSION) || R_CONNECTIONS_VERSION != 1
-#error "Unsupported connections API version"
-#endif
-
-typedef struct {
-  char *url;
-  char *buf;
-  char *cur;
-  int has_data;
-  int has_more;
-  int used;
-  int partial;
-  size_t size;
-  size_t limit;
-  CURLM *manager;
-  CURL *handle;
-  reference *ref;
-} request;
-
 /* Notes:
  *  - First check for unhandled messages in curl_multi_info_read() before curl_multi_perform()
  *  - Use Rf_eval() to callback instead of R_tryEval() to propagate interrupt or error back to C
@@ -34,6 +13,14 @@ multiref *get_multiref(SEXP ptr){
   if(!mref)
     Rf_error("multiref pointer is dead");
   return mref;
+}
+
+CURLM *get_curlm(SEXP con){
+  SEXP ptr = R_ExternalPtrProtected(Rf_getAttrib(con, Rf_install("conn_id")));
+  CURLM *m = (CURLM*) R_ExternalPtrAddr(ptr);
+  if(!m)
+    Rf_error("CURLM pointer is dead");
+  return m;
 }
 
 void multi_release(reference *ref){
@@ -269,12 +256,11 @@ SEXP R_multi_list(SEXP pool_ptr){
 
 SEXP R_multi_fdset(SEXP pool_ptr){
   CURLM *multi;
-  if (Rf_inherits(pool_ptr, "curl_multi")) {
+  if(Rf_inherits(pool_ptr, "curl")){
+    multi = get_curlm(pool_ptr);
+  } else {
     multiref *mref = get_multiref(pool_ptr);
     multi = mref->m;
-  } else {
-    SEXP xptr = Rf_getAttrib(pool_ptr, Rf_install("conn_id"));
-    multi = (CURLM *) R_ExternalPtrAddr(R_ExternalPtrProtected(xptr));
   }
   fd_set read_fd_set, write_fd_set, exc_fd_set;
   int max_fd, i, num_read = 0, num_write = 0, num_exc = 0;


### PR DESCRIPTION
Some necessary changes so that packages such as {elmer} can continue to use curl connections for streaming whilst adopting event-driven async using `later::later_fd()`.

- Stores a reference to the curl request so it can be accessed. The external pointer on R connections is to an `int *` id member, so there is no way of getting the struct address from it. We store it efficiently in the `EXTPTR_PROT` cell of the external pointer.
- So that `curl::multi_fdset()` can return the relevant fds from an R curl connection.
- Updates the async (non-blocking) read logic for curl connections in `rcurl_read()`:
  + Always fetch data (as this is called after fds are detected as ready)
  + Ensures non-blocking reads do not wait (was the case previously if no data was returned)
  + Tests still pass after this change